### PR TITLE
Don't link to libc++ since Dobby doesn't depend on it

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -81,7 +81,6 @@ fn main() -> Result<()> {
     }
 
     println!("cargo:rustc-link-lib=static=dobby");
-    println!("cargo:rustc-link-lib=dylib=c++");
 
     let binding_path = out_dir.join("bindings.rs");
     let bindings = builder()


### PR DESCRIPTION
事实上, Dobby 是 `-nostdlib++` 的(至少在安卓系统上如此). 项目里的 `prebuilt/android/$(abi)/libdobby.so` 也不含对 `libc++_shared.so` 的依赖.
```bash
$ readelf -d libdobby.so | rg NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [liblog.so]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so]  
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so] 
 0x0000000000000001 (NEEDED)             Shared library: [libc.so]  
```
`println!("cargo:rustc-link-lib=dylib=c++");` 在安卓系统上反而错误地链接了 `libc++_shared.so`, 移除后恢复正常.